### PR TITLE
Revert to previous install script

### DIFF
--- a/admin/install_mule.sh
+++ b/admin/install_mule.sh
@@ -140,16 +140,7 @@ echo "[INFO] Installing against Python $PYTHONVER"
 
 # Setup a temporary directory where the install will be initially created
 SCRATCHDIR=$(mktemp -d)
-# pkg_loc=$($mule_python_exec -c "import site ; print(site.getsitepackages()[0])")
-# if [[ $pkg_loc == *"dist-packages"* ]]; then
-#     debian_like=true
-#     SCRATCHLIB=$SCRATCHDIR/local/lib/$PYTHONEXEC/dist-packages
-# else
-#     debian_like=false
-#     SCRATCHLIB=$SCRATCHDIR/lib/$PYTHONEXEC/site-packages
-# fi
 SCRATCHLIB=$SCRATCHDIR/lib/$PYTHONEXEC/site-packages
-echo "SCRATCHLIB $SCRATCHLIB"
 
 # Make relative paths absolute
 if [ ! ${LIB_DEST:0:1} == "/" ] ; then
@@ -365,15 +356,6 @@ function unpack_and_copy(){
     module=$1
     egg=$SCRATCHLIB/$module
 
-    loc=$(find $SCRATCHDIR -name *.egg*)
-    bin_loc=$SCRATCHDIR/bin
-    if [[ $loc == *"dist-packages"* ]]; then
-        SCRATCHLIB=$SCRATCHDIR/local/lib/$PYTHONEXEC/dist-packages
-        bin_loc=$SCRATCHDIR/local/bin
-        echo "[INFO] New SCRATCHLIB: $SCRATCHLIB"
-        echo "[INFO] New bin_loc: $bin_loc"
-    fi
-
     # The egg might be zipped - if it is unzip it in place
     if [ ! -d $egg ] ; then
       egg="$SCRATCHLIB/$module*.egg"
@@ -402,7 +384,7 @@ function unpack_and_copy(){
         else
             cp -vr $egg*.*-info $BIN_DEST
         fi
-        cp -vr $bin_loc/* $BIN_DEST/
+        cp -vr $SCRATCHDIR/bin/* $BIN_DEST/
     fi
 }
 


### PR DESCRIPTION
# PR Summary

Code Reviewer: @jennyhickson 

<!-- To be completed by the developer -->

The previous solution for running with github actions doesn't work for all ubuntu environments. Try to do something better here...

It turns out the issue I was previously trying to fix is only an issue when using the system python which isn't recommended. As I've already changed the CI to using the `setup-python` action, this removed this issue, so we can revert back to the original install script.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number
- fixes #issue-number
- is related to #issue-number
-->

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [x] I have performed a self-review of my own code
- [x] My code follows the project's style guidelines
- [x] Comments have been included that aid undertanding and enhance the
      readability of the code
- [x] My changes generate no new warnings

## Testing

- [x] I have tested this change locally, using the rose-stem suite
- [x] If any tests fail (rose-stem or CI) the reason is understood and
      acceptable (eg. kgo changes)
- [x] I have added tests to cover new functionality as appropriate (eg. system
      tests, unit tests, etc.)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [x] This change does not introduce security vulnerabilities
- [x] I have reviewed the code for potential security issues
- [x] Sensitive data is properly handled (if applicable)
- [x] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [x] Performance of the code has been considered and, if applicable, suitable
      performance measurements have been conducted

## Contributor License Agreement (CLA)

- [x] **Required** - I confirm that I have read and agree to the project's
      [Contributor License Agreement](todo-enter-link-to-cla)

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](todo-enter-link-to-policy-page) (including
      attribution labels)

## Documentation

- [x] Where appropriate I have updated documentation related to this change and
      confirmed that it builds correctly

# Code Review

<!-- To be completed by the Code Reviewer -->

- [x] All dependencies have been resolved
- [x] Related Issues are properly linked and addressed
- [x] CLA compliance is confirmed
- [x] Code quality standards are met
- [x] Tests are adequate and passing
- [x] Documentation is complete and accurate
- [x] Security considerations have been addressed
- [x] Performance impact is acceptable
