### PR TITLE
Remove validation error for regional rivers

### DIFF
--- a/mule/lib/mule/validators.py
+++ b/mule/lib/mule/validators.py
@@ -572,7 +572,7 @@ def validate_regular_field(umf, field):
         # River routing grid
         # No validation is done for regional rivers
         if umf.fixed_length_header.horiz_grid_type == 0:
-            # Note the river routing diagnostics are restriced to a very
+            # Note the river routing diagnostics are restricted to a very
             # specific fixed global grid; any deviation from this is incorrect
             lon_start_exp = 0.5
             lat_start_exp = -89.5

--- a/mule/lib/mule/validators.py
+++ b/mule/lib/mule/validators.py
@@ -570,6 +570,7 @@ def validate_regular_field(umf, field):
             n_row_exp += 1
     elif field.stash.grid == 23:
         # River routing grid
+        # No validation is done for regional rivers
         if umf.fixed_length_header.horiz_grid_type == 0:
             # Note the river routing diagnostics are restriced to a very
             # specific fixed global grid; any deviation from this is incorrect

--- a/mule/lib/mule/validators.py
+++ b/mule/lib/mule/validators.py
@@ -570,12 +570,9 @@ def validate_regular_field(umf, field):
             n_row_exp += 1
     elif field.stash.grid == 23:
         # River routing grid
-        if umf.fixed_length_header.horiz_grid_type != 0:
-            return ["Field is river routing diag, which is invalid "
-                    "for non-Global domains"]
-        else:
+        if umf.fixed_length_header.horiz_grid_type == 0:
             # Note the river routing diagnostics are restriced to a very
-            # specific fixed grid; any deviation from this is incorrect
+            # specific fixed global grid; any deviation from this is incorrect
             lon_start_exp = 0.5
             lat_start_exp = -89.5
             n_row_exp = 180


### PR DESCRIPTION
# PR Summary

Code Reviewer: @t00sa 

<!-- To be completed by the developer -->

The mule validators raise an error if trying to run with regional rivers. However this is no longer valid (see [this discussion](https://github.com/MetOffice/simulation-systems/discussions/585)). This removes the validation error for these scenarios.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number
- fixes #issue-number
- is related to #issue-number
-->

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's style guidelines
- [ ] Comments have been included that aid undertanding and enhance the
      readability of the code
- [ ] My changes generate no new warnings

## Testing

- [ ] I have tested this change locally, using the rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and
      acceptable (eg. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (eg. system
      tests, unit tests, etc.)

<!-- Describe other testing performed (if applicable) -->

### trac.log

# Test Suite Results - um - um_for_mule_rivers/run1

## Suite Information

| Item | Value |
| :--- | :--- |
| Suite Name | [um_for_mule_rivers/run1](https://cylchub/services/cylc-review/cycles/james.bruten/?suite=um_for_mule_rivers%2Frun1) |
| Suite User | james.bruten |
| Workflow Start | 2026-07-16T08:26:02 |
| Groups Run | mule |

| Dependency | Reference | Main Like |
| :--- | :--- | :--- |
| casim | [MetOffice/casim@2026.07.1](https://github.com/MetOffice/casim/tree/2026.07.1) | True |
| jules | [MetOffice/jules@2026.07.1](https://github.com/MetOffice/jules/tree/2026.07.1) | True |
| moci | [MetOffice/moci@2026.07.1](https://github.com/MetOffice/moci/tree/2026.07.1) | True |
| mule | [james-bruten-mo/mule@rivers_validation](https://github.com/james-bruten-mo/mule/tree/rivers_validation) | False |
| shumlib | [MetOffice/shumlib@2026.07.1](https://github.com/MetOffice/shumlib/tree/2026.07.1) | True |
| socrates | [MetOffice/socrates@2026.07.1](https://github.com/MetOffice/socrates/tree/2026.07.1) | True |
| SimSys_Scripts | [MetOffice/SimSys_Scripts@2026.07.1](https://github.com/MetOffice/SimSys_Scripts/tree/2026.07.1) | True |
| ukca | [MetOffice/ukca@2026.07.1](https://github.com/MetOffice/ukca/tree/2026.07.1) | True |
| um | [MetOffice/um@9c139d0](https://github.com/MetOffice/um/tree/9c139d0) | True |
| um_aux | [MetOffice/um_aux@2026.07.1](https://github.com/MetOffice/um_aux/tree/2026.07.1) | True |
| um_meta | [MetOffice/um_meta@2026.07.1](https://github.com/MetOffice/um_meta/tree/2026.07.1) | True |

## Approvals
### Code Owners
* No UM Code Owners Required
### Config Owners
No UM Config Owners Required
## Task Information
:white_check_mark: succeeded tasks - 43


## Security Considerations

- [ ] This change does not introduce security vulnerabilities
- [ ] I have reviewed the code for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable
      performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)
      (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and
      confirmed that it builds correctly

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
